### PR TITLE
DistantLand/DistantLandForm.cs -- Remove question mark masks from file s...

### DIFF
--- a/MGEgui/DistantLand/DistantLandForm.cs
+++ b/MGEgui/DistantLand/DistantLandForm.cs
@@ -1273,17 +1273,17 @@ namespace MGEgui.DistantLand {
                 FileInfo[] files;
                 Plugins = new Dictionary<string, MWPlugin>();
                 Dirs = new List<string>(dirs);
-                files = dir.GetFiles("*?.esm");
+                files = dir.GetFiles("*.esm");
                 foreach (FileInfo file in files) Plugins.Add(file.Name.ToLower(Statics.Culture), new MWPlugin(file, true));
-                files = dir.GetFiles("*?.esp");
+                files = dir.GetFiles("*.esp");
                 foreach (FileInfo file in files) Plugins.Add(file.Name.ToLower(Statics.Culture), new MWPlugin(file, false));
                 List<string> removeDirs = new List<string>();
                 foreach (string dirName in Dirs) {
                     dir = new DirectoryInfo(dirName);
                     if (dir.Exists) {
-                        files = dir.GetFiles("*?.esm");
+                        files = dir.GetFiles("*.esm");
                         foreach (FileInfo file in files) Plugins.Add(file.Name.ToLower(Statics.Culture) + " > " + dirName, new MWPlugin(file, dirName, true));
-                        files = dir.GetFiles("*?.esp");
+                        files = dir.GetFiles("*.esp");
                         foreach (FileInfo file in files) Plugins.Add(file.Name.ToLower(Statics.Culture) + " > " + dirName, new MWPlugin(file, dirName, false));
                     } else removeDirs.Add(dirName);
                 }
@@ -1300,9 +1300,9 @@ namespace MGEgui.DistantLand {
                 foreach (string dirName in dirs) if (Dirs.IndexOf(dirName) == -1) {
                     DirectoryInfo dir = new DirectoryInfo(dirName);
                     if (dir.Exists) {
-                        FileInfo[] files = dir.GetFiles("*?.esm");
+                        FileInfo[] files = dir.GetFiles("*.esm");
                         foreach (FileInfo file in files) Plugins.Add(file.Name.ToLower(Statics.Culture) + " > " + dirName, new MWPlugin(file, dirName, true));
-                        files = dir.GetFiles("*?.esp");
+                        files = dir.GetFiles("*.esp");
                         foreach (FileInfo file in files) Plugins.Add(file.Name.ToLower(Statics.Culture) + " > " + dirName, new MWPlugin(file, dirName, false));
                     } else removeDirs.Add(dirName);
                 }


### PR DESCRIPTION
This will remove the question marks from the file masks for the Distant Land creation wizard.  This should allow Distant Land to be generated under Wine.  (I cannot test this code personally, since I have no build system for Mono/DotNet.  But once built, I'm willing to give this a shot.)  This is ported from Europop's compatibility work on MGE.
